### PR TITLE
Add tip to fix "RuntimeError: Broken toolchain"

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -1089,3 +1089,25 @@ This can be resolved by create a symbolic link:
 ```bash
 ln -sf /usr/local/cuda/lib/libcuda.dylib /usr/local/cuda/lib/libcuda.1.dylib
 ```
+
+### Mac OS X: RuntimeError: Broken toolchain: cannot link a simple C program
+
+On Mac OS X, when installing tensorflow you might see lots of warnings and errors, ending with a `Broken toolchain: cannot link a simple C program` message:
+
+```
+>>> sudo pip install --upgrade $TF_BINARY_URL
+
+...<lots more warnings and errors>
+
+You have not agreed to the Xcode license agreements, please run 'xcodebuild -license' (for user-level acceptance) or 'sudo xcodebuild -license' (for system-wide acceptance) from within a Terminal window to review and agree to the Xcode license agreements.
+
+...<more stack trace output>
+
+  File "numpy/core/setup.py", line 653, in get_mathlib_info
+
+    raise RuntimeError("Broken toolchain: cannot link a simple C program")
+
+RuntimeError: Broken toolchain: cannot link a simple C program
+```
+
+This is typically because you have the Xcode build tools installed, but you still need to accept the license agreements.  To resolve it, accept the license agreement by opening Xcode, or by running `xcodebuild -license` from the command line.


### PR DESCRIPTION
This issue hit me when I tried to install TensorFlow.  I checked the "Common Problems" page and when I didn't see this issue there I searched the interwebz to find [the fix](http://stackoverflow.com/a/26764577/112705).  Only after I found the fix did I notice the helpful `You have not agreed to the Xcode license agreements` message further up in the Terminal output...

TESTING

Here's what the updated section of the README looks like in [my forked repository](https://github.com/daj/tensorflow/blob/0ea28c550a8d432b09055d5e2288dc3d18dd7c7e/tensorflow/g3doc/get_started/os_setup.md):

![screen shot 2016-10-10 at 2 29 30 pm](https://cloud.githubusercontent.com/assets/739125/19246784/0f70ae50-8ef6-11e6-9737-0fc68144428f.png)
